### PR TITLE
docs: badges update

### DIFF
--- a/.changeset/giant-snakes-bet.md
+++ b/.changeset/giant-snakes-bet.md
@@ -1,0 +1,5 @@
+---
+"@crescendolab/css-var-ts": patch
+---
+
+docs: badges update

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 Type-safe, ergonomic utilities for authoring, registering, and consuming CSS Custom Properties (CSS Variables) in TypeScript.
 
-[![npm (scoped)](https://img.shields.io/npm/v/@crescendolab/css-var-ts?color=blue&label=npm)](https://www.npmjs.com/package/@crescendolab/css-var-ts)
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/crescendolab-open/css-var-ts/ci.yml?branch=main&label=ci&logo=github&color=blue)](https://github.com/crescendolab-open/css-var-ts/actions)
+[![npm (scoped)](https://img.shields.io/npm/v/@crescendolab/css-var-ts)](https://www.npmjs.com/package/@crescendolab/css-var-ts)
 
 ---
 


### PR DESCRIPTION
This pull request makes a minor documentation update to the project. The main change is an update to the badges in the `README.md` file to simplify the npm badge and remove the CI badge.

* Documentation update:
  * [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Simplified the npm badge and removed the CI workflow badge from the top of the README.
  * [`.changeset/giant-snakes-bet.md`](diffhunk://#diff-b39b4eab9b02a6af2c893f87144a03cf5dab127320bfdd4926280051b9f9679bR1-R5): Added a patch changeset describing the badge update.